### PR TITLE
Expand bloom filter bindings with additional operations

### DIFF
--- a/docs/source/filters/bloom_filter.rst
+++ b/docs/source/filters/bloom_filter.rst
@@ -1,0 +1,16 @@
+Bloom Filter
+============
+
+A Bloom filter provides fast probabilistic set membership checks with configurable false
+positive probabilities.
+
+Creating and using a Bloom filter::
+
+    from datasketches import create_bloom_filter
+
+    bf = create_bloom_filter(1000, 0.01)
+    bf.update("item")
+    bf.query("item")
+
+The binding also supports integers and raw bytes as inputs, merging with other filters,
+serialization, and creation by explicit size using ``create_bloom_filter_by_size``.

--- a/docs/source/filters/index.rst
+++ b/docs/source/filters/index.rst
@@ -1,0 +1,7 @@
+Filters
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   bloom_filter

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,14 @@ This problem may also be known as **heavy hitters** or **TopK**
 
    frequency/index
 
+Filters
+#######
+
+.. toctree::
+   :maxdepth: 2
+
+   filters/index
+
 Vector Sketches
 ###############
 

--- a/src/bloom_filter_wrapper.cpp
+++ b/src/bloom_filter_wrapper.cpp
@@ -19,6 +19,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/bytes.h>
 
 #include "bloom_filter.hpp"
 #include "common_defs.hpp"
@@ -30,28 +31,72 @@ void bind_bloom_filter(nb::module_ &m, const char* name) {
   using namespace datasketches;
   using bloom_filter_type = bloom_filter_alloc<A>;
 
-  // Start with just one simple function
-  m.def("create_bloom_filter", 
-         [](uint64_t max_distinct_items, double target_false_positive_prob) {
-           return bloom_filter_type::builder::create_by_accuracy(max_distinct_items, target_false_positive_prob);
-         },
-         nb::arg("max_distinct_items"), nb::arg("target_false_positive_prob"),
-         "Creates a Bloom filter with optimal parameters for the given accuracy requirements");
+  // Creation helpers
+  m.def(
+      "create_bloom_filter",
+      [](uint64_t max_distinct_items, double target_false_positive_prob) {
+        return bloom_filter_type::builder::create_by_accuracy(max_distinct_items, target_false_positive_prob);
+      },
+      nb::arg("max_distinct_items"), nb::arg("target_false_positive_prob"),
+      "Creates a Bloom filter with optimal parameters for the given accuracy requirements");
+  m.def(
+      "create_bloom_filter_by_size",
+      [](uint64_t num_bits, uint8_t num_hashes) {
+        return bloom_filter_type::builder::create_by_size(num_bits, num_hashes);
+      },
+      nb::arg("num_bits"), nb::arg("num_hashes"),
+      "Creates a Bloom filter with explicit size and number of hash functions");
 
-  // Bind the class with minimal methods
+  // Bind the class with expanded methods
   nb::class_<bloom_filter_type>(m, name)
     .def("is_empty", &bloom_filter_type::is_empty,
          "Returns True if the filter has seen no items, otherwise False")
     .def("reset", &bloom_filter_type::reset,
          "Resets the filter to its original empty state")
-    .def("update", static_cast<void (bloom_filter_type::*)(const std::string&)>(&bloom_filter_type::update), 
+    .def("update", static_cast<void (bloom_filter_type::*)(const std::string&)>(&bloom_filter_type::update),
          nb::arg("item"),
          "Updates the filter with the given string")
-    .def("query", static_cast<bool (bloom_filter_type::*)(const std::string&) const>(&bloom_filter_type::query), 
+    .def("update", static_cast<void (bloom_filter_type::*)(uint64_t)>(&bloom_filter_type::update),
          nb::arg("item"),
-         "Queries the filter for the given string");
+         "Updates the filter with the given 64-bit integer")
+    .def("update",
+         [](bloom_filter_type& bf, const nb::bytes& bytes) {
+           bf.update(bytes.c_str(), bytes.size());
+         },
+         nb::arg("item"),
+         "Updates the filter with the given bytes")
+    .def("query", static_cast<bool (bloom_filter_type::*)(const std::string&) const>(&bloom_filter_type::query),
+         nb::arg("item"),
+         "Queries the filter for the given string")
+    .def("query", static_cast<bool (bloom_filter_type::*)(uint64_t) const>(&bloom_filter_type::query),
+         nb::arg("item"),
+         "Queries the filter for the given 64-bit integer")
+    .def("query",
+         [](const bloom_filter_type& bf, const nb::bytes& bytes) {
+           return bf.query(bytes.c_str(), bytes.size());
+         },
+         nb::arg("item"),
+         "Queries the filter for the given bytes")
+    .def("merge", &bloom_filter_type::merge, nb::arg("other"),
+         "Merges the provided bloom filter into this one")
+    .def("get_serialized_size_bytes", &bloom_filter_type::get_serialized_size_bytes,
+         "Returns the size of the serialized filter, in bytes")
+    .def(
+        "serialize",
+        [](const bloom_filter_type& bf) {
+          auto bytes = bf.serialize();
+          return nb::bytes(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        },
+        "Serializes the filter into a bytes object")
+    .def_static(
+        "deserialize",
+        [](const nb::bytes& bytes) {
+          return bloom_filter_type::deserialize(bytes.c_str(), bytes.size());
+        },
+        nb::arg("bytes"),
+        "Creates a bloom filter from the provided bytes");
 }
 
 void init_bloom_filter(nb::module_ &m) {
   bind_bloom_filter<std::allocator<uint8_t>>(m, "bloom_filter");
-} 
+}

--- a/tests/bloom_filter_test.py
+++ b/tests/bloom_filter_test.py
@@ -16,7 +16,7 @@
 # under the License.
   
 import unittest
-from datasketches import create_bloom_filter
+from datasketches import create_bloom_filter, create_bloom_filter_by_size, bloom_filter
 
 class BloomFilterTest(unittest.TestCase):
   def test_create_bloom_filter(self):
@@ -45,6 +45,17 @@ class BloomFilterTest(unittest.TestCase):
     
     # Query for item not in filter
     self.assertFalse(bf.query("other_item"))
+
+  def test_bloom_filter_numeric_and_bytes(self):
+    """Test update and query with numeric and byte inputs"""
+    bf = create_bloom_filter(1000, 0.01)
+
+    bf.update(12345)
+    self.assertTrue(bf.query(12345))
+
+    data = b"abcdef"
+    bf.update(data)
+    self.assertTrue(bf.query(data))
 
   def test_bloom_filter_reset(self):
     """Test resetting the bloom filter to empty state"""
@@ -75,6 +86,18 @@ class BloomFilterTest(unittest.TestCase):
     non_items = ["not_item1", "not_item2", "not_item3"]
     for item in non_items:
       self.assertFalse(bf.query(item), f"Item {item} should not be found")
+
+  def test_bloom_filter_merge(self):
+    """Test merging two bloom filters"""
+    bf1 = create_bloom_filter(1000, 0.01)
+    bf2 = create_bloom_filter(1000, 0.01)
+
+    bf1.update("a")
+    bf2.update("b")
+    bf1.merge(bf2)
+
+    self.assertTrue(bf1.query("a"))
+    self.assertTrue(bf1.query("b"))
 
   def test_bloom_filter_false_positives(self):
     """Test that bloom filter can have false positives (this is expected behavior)"""
@@ -107,6 +130,12 @@ class BloomFilterTest(unittest.TestCase):
         bf = create_bloom_filter(max_items, false_positive_rate)
         self.assertIsNotNone(bf)
         self.assertTrue(bf.is_empty())
+
+  def test_bloom_filter_create_by_size(self):
+    """Test creating bloom filter with explicit size parameters"""
+    bf = create_bloom_filter_by_size(1024, 4)
+    self.assertIsNotNone(bf)
+    self.assertTrue(bf.is_empty())
 
   def test_bloom_filter_string_types(self):
     """Test that bloom filter works with different string types"""
@@ -152,5 +181,13 @@ class BloomFilterTest(unittest.TestCase):
     bf.update(number_string)
     self.assertTrue(bf.query(number_string))
 
+  def test_bloom_filter_serialize(self):
+    """Test serialization and deserialization round-trip"""
+    bf = create_bloom_filter(1000, 0.01)
+    bf.update("item")
+    data = bf.serialize()
+    bf2 = bloom_filter.deserialize(data)
+    self.assertTrue(bf2.query("item"))
+
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend bloom filter bindings with numeric and byte updates, merging, serialization, and builder options
- document bloom filter usage and add dedicated section in docs
- broaden bloom filter tests to cover new functionality

## Testing
- `python setup.py build_ext --inplace` *(fails: ModuleNotFoundError: No module named 'setuptools')*
- `cmake -S . -B build` *(fails: Could NOT find Python (missing: Python_NumPy_INCLUDE_DIRS NumPy))*
- `pytest tests/bloom_filter_test.py` *(fails: ImportError: /workspace/datasketches-python/_datasketches.so: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_689671db5080832285df15acfeec60d5